### PR TITLE
Add Travis build, update tests with mock KVM and ioctlFunc implementa…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: go
+go:
+  - 1.4.2
+  - tip
+before_script:
+  - go get -d ./...
+script:
+  - go test -v ./...

--- a/darity_test.go
+++ b/darity_test.go
@@ -1,13 +1,45 @@
+// +build linux
+
+// These tests use a mocked KVM virtual device and allow different ioctl
+// implementations to be used.
+
 package darity
 
 import (
+	"io/ioutil"
+	"os"
 	"testing"
 )
 
-func TestAPIVersion(t *testing.T) {
-	v, err := APIVersion()
+// TestAPIVersion verifies that Client.APIVersion returns the
+// KVM API version identified by the Version constant.
+func TestAPIVersionKVM(t *testing.T) {
+	c := &Client{
+		ioctl: func(fd uintptr, request int, argp uintptr) (int, error) {
+			return Version, nil
+		},
+	}
+
+	v, err := c.APIVersion()
 	if err != nil {
 		t.Errorf("could not get API version: %q", err.Error())
 	}
-	t.Logf("APIVersion: %d", v)
+
+	if want, got := v, Version; want != got {
+		t.Fatalf("unexpected KVM API version: %d != %d", want, got)
+	}
+}
+
+// tempFile creates a temporary file for use as a mock KVM virtual device, and
+// returns the file and a function to clean it up and remove it on completion.
+func tempFile(t *testing.T) (*os.File, func()) {
+	temp, err := ioutil.TempFile(os.TempDir(), "darity")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return temp, func() {
+		_ = temp.Close()
+		_ = os.Remove(temp.Name())
+	}
 }


### PR DESCRIPTION
…tions

First pass at making this thing testable.  I figure if we can mock the KVM virtual device (to capture reads/writes) and `ioctl()` (to send/receive other data), then we should be able to do some pretty solid testing in the future.

To enable Travis build, go here: https://travis-ci.org/profile/kitschysynq, flick the switch on, and then merge this commit and it should build!

/cc @kitschysynq
