### PR TITLE
Don't build on non-Linux platforms

### DIFF
--- a/darity.go
+++ b/darity.go
@@ -1,6 +1,6 @@
-// Package darity provides a set of functions for interacting with KVM.
-//
 // +build linux
+
+// Package darity provides a set of functions for interacting with KVM.
 package darity
 
 import (


### PR DESCRIPTION
It seems the build tag needs a bit of separation from the doc comment.  New behavior:

```
[zsh|matt@nerr-2]:~/darity 0 *(master) ± go build
[zsh|matt@nerr-2]:~/darity 0 *(master) ± GOOS=darwin go build
can't load package: package .: no buildable Go source files in /home/matt/darity
[zsh|matt@nerr-2]:~/darity 0 *(master) ± go test -v .
=== RUN TestAPIVersionKVM
--- PASS: TestAPIVersionKVM (0.00s)
PASS
ok      _/home/matt/darity      0.001s
[zsh|matt@nerr-2]:~/darity 0 *(master) ± GOOS=darwin go test -v .
can't load package: package .: no buildable Go source files in /home/matt/darity
```
