### PR TITLE
Return uintptr from ioctlFunc, leave conversions up to the caller

### DIFF
--- a/darity_test.go
+++ b/darity_test.go
@@ -15,12 +15,12 @@ import (
 // KVM API version identified by the Version constant.
 func TestAPIVersionKVM(t *testing.T) {
 	c := &Client{
-		ioctl: func(fd uintptr, request int, argp uintptr) (int, error) {
+		ioctl: func(fd uintptr, request int, argp uintptr) (uintptr, error) {
 			if request != kvmGetAPIVersion {
 				t.Fatalf("unexpected ioctl request number: %d", request)
 			}
 
-			return Version, nil
+			return uintptr(Version), nil
 		},
 	}
 
@@ -36,7 +36,7 @@ func TestAPIVersionKVM(t *testing.T) {
 
 func TestCreateVM(t *testing.T) {
 	c := &Client{
-		ioctl: func(fd uintptr, request int, argp uintptr) (int, error) {
+		ioctl: func(fd uintptr, request int, argp uintptr) (uintptr, error) {
 			if request != kvmCreateVM {
 				t.Fatalf("unexpected ioctl request number: %d", request)
 			}


### PR DESCRIPTION
Some operations will require a `uintptr` value directly, so let's return it that way from `ioctlFunc`, so that the caller can decide what kind of data they need. (And so we don't have to keep converting back and forth between the two)
